### PR TITLE
remove useless braces

### DIFF
--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/task/TaskExecutor.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/task/TaskExecutor.java
@@ -683,13 +683,13 @@ public final class TaskExecutor {
     });
 
     // finalize OutputWriters for additional tagged children
-    vertexHarness.getWritersToAdditionalChildrenTasks().values().forEach(outputWriters -> {
+    vertexHarness.getWritersToAdditionalChildrenTasks().values().forEach(outputWriters ->
       outputWriters.forEach(outputWriter -> {
         outputWriter.close();
         final Optional<Long> writtenBytes = outputWriter.getWrittenBytes();
         writtenBytes.ifPresent(writtenBytesList::add);
       });
-    });
+    );
 
     long totalWrittenBytes = 0;
     for (final Long writtenBytes : writtenBytesList) {


### PR DESCRIPTION
remove useless curly braces because lambda containing only one statement should not nest this statement in a block